### PR TITLE
update to latest CLS and latest hapi plugin API

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,24 +1,29 @@
 'use strict';
 
-module.exports = {
-  name     : 'hapi-cls',
-  version  : '1.1.1',
-  register : function (plugin, options, next) {
+var HapiCls = {
+  register : function (server, options, next) {
     if (!options.namespace) next(new TypeError('namespace name required'));
 
     var cls = require('continuation-local-storage');
     var ns = cls.getNamespace(options.namespace);
     if (!ns) ns = cls.createNamespace(options.namespace);
 
-    plugin.app.clsNamespace = ns;
+    server.app.clsNamespace = ns;
 
-    plugin.ext('onRequest', function (request, continuation) {
+    server.ext('onRequest', function (request, reply) {
       ns.bindEmitter(request.raw.req);
       ns.bindEmitter(request.raw.res);
 
-      ns.run(function () { continuation(); });
+      ns.run(function () { reply.continue(); });
     });
 
     next();
   }
 };
+
+HapiCls.register.attributes = {
+  name     : 'hapi-cls',
+  version  : '1.2.0'
+};
+
+module.exports = HapiCls;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-cls",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "continuation-local storage extension for hapi",
   "main": "index.js",
   "scripts": {
@@ -23,9 +23,11 @@
     "url": "https://github.com/othiym23/hapi-cls/issues"
   },
   "devDependencies": {
-    "lab": "~1.1.3"
+    "hapi": "16.x.x",
+    "code": "4.x.x",
+    "lab": "11.x.x"
   },
   "dependencies": {
-    "continuation-local-storage": "~2.4.3"
+    "continuation-local-storage": "3.2.x"
   }
 }


### PR DESCRIPTION
- update to current CLS npm version
- update to latest hapi plugin API, hapi version, and associated current test framework packages
- got tests passing with the above changes
- updated README to reflect required client code syntax changes
- addresses issue #2 
- note this PR is more current than the related other open PR #1 